### PR TITLE
fix(proxy): 修复厂商Base URL中path部分不生效，仅host生效的问题

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -112,6 +113,16 @@ func (p *ProxyServer) Start(ctx context.Context) error {
 		req.URL.Scheme = "https"
 		req.URL.Host = targetURL.Host
 		req.Host = targetURL.Host
+
+		if targetURL.Path != "" && targetURL.Path != "/" {
+			targetPath := strings.TrimSuffix(targetURL.Path, "/")
+			reqPath := req.URL.Path
+			if !strings.HasPrefix(reqPath, "/") {
+				reqPath = "/" + reqPath
+			}
+			req.URL.Path = targetPath + reqPath
+		}
+
 		log.Printf("[Proxy] %s %s -> https://%s%s", req.Method, req.URL.Path, targetURL.Host, req.URL.Path)
 	}
 


### PR DESCRIPTION
## 问题描述

当前代码只提取 `base_url` 的 host 部分，丢弃了 path。导致包含自定义路径的 Base URL（如cloud.infini-ai.com/`maas/coding`）无法正常工作。

## 修复内容

完整保留 Base URL 的 path 部分，正确拼接到请求 endpoint。

## ⚠️ 破坏性变更说明（Breaking Change）

**这个修改会改变 Base URL 的解析方式，现有用户可能需要调整配置。**

### 变更对比

| Base URL 配置 | 本PR前实际请求 | 本PR后实际请求 | 是否需要修改配置 |
|--------------|--------------|--------------|----------------|
| `https://api.xxxx.com/v1` | api.xxxx.com`/v1/completion` ✅ | api.xxxx.com`/v1/v1/completion` ❌ | **需要** → 改为 `https://api.openai.com` |
| `https://api.xxxx.com` | api.xxxx.com`/v1/completion` ✅ | api.xxxx.com`/v1/completion` ✅ | 不需要 |
| `https://api.xxxx.com/maas/coding` | api.xxxx.com`/v1/completion` ❌ | api.xxxx.com`/maas/coding/v1/completion` ✅ | 不需要（之前本来就不能用）|

### 用户迁移指南

如果用户之前配置的是：
- `https://api.openai.com/v1` → 需要改为 `https://api.openai.com`
- `https://任意地址/v1` → 需要去掉末尾的 `/v1`

如果用户之前配置的是：
- `https://api.openai.com`（不带 `/v1`）→ 之前可能不工作，修复后正常工作，无需修改

## 测试情况

**我已测试：**
- ✅ 带自定义路径的 Base URL（如 `cloud.infini-ai.com/maas/coding`）→ 正常工作

**我无法测试（缺少账号）：**
- ❌ 标准 OpenAI （不带自定义路径）配置的回归测试

**逻辑分析 未实测：**
- 不带 path 的 Base URL 行为不变（空字符串拼接）
- 但带 `/v1` 的情况会变成 `/v1/v1`，需要用户修改配置

## 请求协助

麻烦作者帮忙：
1. 用 `阿里云coding plan` 账号测试 `https://coding.dashscope.aliyuncs.com` (去掉/v1)能否正常工作
2. 评估现有用户的影响范围
3. 考虑是否需要在文档中添加迁移说明

如果这个 breaking change 不可接受，我可以换一种方案（例如只保留非 `/v1` 的 path，自动去除末尾 `/v1`），请告知。